### PR TITLE
use creator of ics721 for collection info

### DIFF
--- a/contracts/sg-ics721/src/execute.rs
+++ b/contracts/sg-ics721/src/execute.rs
@@ -44,7 +44,7 @@ impl Ics721Execute for SgIcs721Contract {
             symbol: class.id.clone().into(),
             minter: env.contract.address.to_string(),
             collection_info: sg721::CollectionInfo {
-                // source owner could be: 1. regular owner, 2. contract, or 3. multisig
+                // source owner could be: 1. regular wallet, 2. contract, or 3. multisig
                 // bech32 calculation for 2. and 3. leads to unknown address
                 // therefore, we use ics721 creator as owner
                 creator: ics721_contract_info.creator,

--- a/contracts/sg-ics721/src/execute.rs
+++ b/contracts/sg-ics721/src/execute.rs
@@ -1,9 +1,6 @@
 use cosmwasm_std::{from_json, to_json_binary, Addr, Binary, Deps, DepsMut, Env, StdResult};
 use ics721::{
-    execute::Ics721Execute,
-    state::CollectionData,
-    token_types::Class,
-    utils::{convert_owner_chain_address, get_collection_data},
+    execute::Ics721Execute, state::CollectionData, token_types::Class, utils::get_collection_data,
 };
 use sg721_base::msg::{CollectionInfoResponse, QueryMsg};
 
@@ -47,6 +44,9 @@ impl Ics721Execute for SgIcs721Contract {
             symbol: class.id.clone().into(),
             minter: env.contract.address.to_string(),
             collection_info: sg721::CollectionInfo {
+                // source owner could be: 1. regular owner, 2. contract, or 3. multisig
+                // bech32 calculation for 2. and 3. leads to unknown address
+                // therefore, we use ics721 creator as owner
                 creator: ics721_contract_info.creator,
                 description: "".to_string(),
                 image: "https://arkprotocol.io".to_string(),
@@ -62,22 +62,6 @@ impl Ics721Execute for SgIcs721Contract {
             let class_data_result: StdResult<CollectionData> = from_json(binary);
             if class_data_result.is_ok() {
                 let class_data = class_data_result?;
-                match class_data.owner {
-                    Some(owner) =>
-                    // owner from source chain is used
-                    {
-                        instantiate_msg.collection_info.creator =
-                            convert_owner_chain_address(env, owner.as_str())?
-                    }
-                    None =>
-                    // ics721 creator is used, in case of none
-                    {
-                        let ics721_contract_info = deps
-                            .querier
-                            .query_wasm_contract_info(env.contract.address.to_string())?;
-                        instantiate_msg.collection_info.creator = ics721_contract_info.creator;
-                    }
-                }
                 // set name and symbol
                 instantiate_msg.symbol = class_data.symbol;
                 instantiate_msg.name = class_data.name;

--- a/contracts/sg-ics721/src/testing/integration_tests.rs
+++ b/contracts/sg-ics721/src/testing/integration_tests.rs
@@ -846,20 +846,12 @@ fn test_do_instantiate_and_mint() {
             .wrap()
             .query_wasm_smart(nft_contract.clone(), &Sg721QueryMsg::CollectionInfo {})
             .unwrap();
-        let (_source_hrp, source_data, source_variant) = bech32::decode(
-            test.app
-                .api()
-                .addr_make(COLLECTION_OWNER_SOURCE_CHAIN)
-                .as_str(),
-        )
-        .unwrap();
-        let target_owner = bech32::encode(BECH32_PREFIX_HRP, source_data, source_variant).unwrap();
 
         assert_eq!(
             collection_info,
             CollectionInfoResponse {
                 // creator based on owner from collection in soure chain
-                creator: target_owner, // creator is set to owner as defined by ClassData
+                creator: test.app.api().addr_make(ICS721_CREATOR).to_string(),
                 description: "".to_string(),
                 image: "https://arkprotocol.io".to_string(),
                 external_link: None,
@@ -1705,20 +1697,10 @@ fn test_do_instantiate_and_mint_no_instantiate() {
         .wrap()
         .query_wasm_smart(nft_contract.clone(), &Sg721QueryMsg::CollectionInfo {})
         .unwrap();
-    let (_source_hrp, source_data, source_variant) = bech32::decode(
-        test.app
-            .api()
-            .addr_make(COLLECTION_OWNER_SOURCE_CHAIN)
-            .as_str(),
-    )
-    .unwrap();
-    let target_owner = bech32::encode(BECH32_PREFIX_HRP, source_data, source_variant).unwrap();
-
     assert_eq!(
         collection_info,
         CollectionInfoResponse {
-            // creator is set to owner as defined by ClassData in 1st transfer!
-            creator: target_owner,
+            creator: test.app.api().addr_make(ICS721_CREATOR).to_string(),
             description: "".to_string(),
             image: "https://arkprotocol.io".to_string(),
             external_link: None,

--- a/packages/ics721/src/execute.rs
+++ b/packages/ics721/src/execute.rs
@@ -332,14 +332,14 @@ where
             minter: env.contract.address.to_string(),
         };
 
-        // unwrapped to collection data and in case of success, set name and symbol
-        if let Some(binary) = class.data.clone() {
-            let class_data_result: StdResult<CollectionData> = from_json(binary);
-            if class_data_result.is_ok() {
-                let class_data = class_data_result?;
-                instantiate_msg.symbol = class_data.symbol;
-                instantiate_msg.name = class_data.name;
-            }
+        // use collection data for setting name and symbol
+        let collection_data = class
+            .data
+            .clone()
+            .and_then(|binary| from_json::<CollectionData>(binary).ok());
+        if let Some(collection_data) = collection_data {
+            instantiate_msg.name = collection_data.name;
+            instantiate_msg.symbol = collection_data.symbol;
         }
 
         to_json_binary(&instantiate_msg)


### PR DESCRIPTION
Owner from source cant be source. Though bech32 does calculate it propery, but source owner could be: 1. regular wallet, 2. contract, or 3. multisig. So bech32 calculation for 2. and 3. leads to unknown address - hence, we use ics721 creator as owner.