### PR TITLE
new CW721_ADMIN store

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 set dotenv-load
 
 platform := if arch() =~ "aarch64" {"linux/arm64"} else {"linux/amd64"}
-image := if arch() =~ "aarch64" {"cosmwasm/workspace-optimizer-arm64:0.14.0"} else {"cosmwasm/workspace-optimizer:0.14.0"}
+image := if arch() =~ "aarch64" {"cosmwasm/workspace-optimizer-arm64:0.15.0"} else {"cosmwasm/workspace-optimizer:0.15.0"}
 
 alias log := optimize-watch
 

--- a/packages/ics721/schema/ics721.json
+++ b/packages/ics721/schema/ics721.json
@@ -10,6 +10,13 @@
       "cw721_base_code_id"
     ],
     "properties": {
+      "cw721_admin": {
+        "description": "The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "cw721_base_code_id": {
         "description": "Code ID of cw721-ics contract. A new cw721-ics will be instantiated for each new IBCd NFT classID.\n\nNOTE: this _must_ correspond to the cw721-base contract. Using a regular cw721 may cause the ICS 721 interface implemented by this contract to stop working, and IBCd away NFTs to be unreturnable as cw721 does not have a mint method in the spec.",
         "type": "integer",
@@ -164,31 +171,6 @@
         "properties": {
           "callback": {
             "$ref": "#/definitions/CallbackMsg"
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
-          "receive_proxy_nft"
-        ],
-        "properties": {
-          "receive_proxy_nft": {
-            "type": "object",
-            "required": [
-              "eyeball",
-              "msg"
-            ],
-            "properties": {
-              "eyeball": {
-                "type": "string"
-              },
-              "msg": {
-                "$ref": "#/definitions/Cw721ReceiveMsg"
-              }
-            },
-            "additionalProperties": false
           }
         },
         "additionalProperties": false
@@ -922,6 +904,20 @@
         "additionalProperties": false
       },
       {
+        "description": "Gets the admin address for instantiating new cw721 contracts. In case of None, contract is immutable.",
+        "type": "object",
+        "required": [
+          "cw721_admin"
+        ],
+        "properties": {
+          "cw721_admin": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Gets a list of classID as key (from NonFungibleTokenPacketData) and cw721 contract as value (instantiated for that classID).",
         "type": "object",
         "required": [
@@ -1125,6 +1121,31 @@
         },
         "ClassId": {
           "description": "A class ID according to the ICS-721 spec. The newtype pattern is used here to provide some distinction between token and class IDs in the type system.",
+          "type": "string"
+        }
+      }
+    },
+    "cw721_admin": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Nullable_Nullable_Addr",
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
           "type": "string"
         }
       }

--- a/packages/ics721/schema/raw/execute.json
+++ b/packages/ics721/schema/raw/execute.json
@@ -41,31 +41,6 @@
         }
       },
       "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "required": [
-        "receive_proxy_nft"
-      ],
-      "properties": {
-        "receive_proxy_nft": {
-          "type": "object",
-          "required": [
-            "eyeball",
-            "msg"
-          ],
-          "properties": {
-            "eyeball": {
-              "type": "string"
-            },
-            "msg": {
-              "$ref": "#/definitions/Cw721ReceiveMsg"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/packages/ics721/schema/raw/instantiate.json
+++ b/packages/ics721/schema/raw/instantiate.json
@@ -6,6 +6,13 @@
     "cw721_base_code_id"
   ],
   "properties": {
+    "cw721_admin": {
+      "description": "The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "cw721_base_code_id": {
       "description": "Code ID of cw721-ics contract. A new cw721-ics will be instantiated for each new IBCd NFT classID.\n\nNOTE: this _must_ correspond to the cw721-base contract. Using a regular cw721 may cause the ICS 721 interface implemented by this contract to stop working, and IBCd away NFTs to be unreturnable as cw721 does not have a mint method in the spec.",
       "type": "integer",

--- a/packages/ics721/schema/raw/query.json
+++ b/packages/ics721/schema/raw/query.json
@@ -190,6 +190,20 @@
       "additionalProperties": false
     },
     {
+      "description": "Gets the admin address for instantiating new cw721 contracts. In case of None, contract is immutable.",
+      "type": "object",
+      "required": [
+        "cw721_admin"
+      ],
+      "properties": {
+        "cw721_admin": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Gets a list of classID as key (from NonFungibleTokenPacketData) and cw721 contract as value (instantiated for that classID).",
       "type": "object",
       "required": [

--- a/packages/ics721/schema/raw/response_to_cw721_admin.json
+++ b/packages/ics721/schema/raw/response_to_cw721_admin.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Nullable_Nullable_Addr",
+  "anyOf": [
+    {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Addr"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    {
+      "type": "null"
+    }
+  ],
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    }
+  }
+}

--- a/packages/ics721/src/execute.rs
+++ b/packages/ics721/src/execute.rs
@@ -19,8 +19,8 @@ use crate::{
     },
     msg::{CallbackMsg, ExecuteMsg, InstantiateMsg, MigrateMsg},
     state::{
-        CollectionData, UniversalAllNftInfoResponse, CLASS_ID_TO_CLASS, CLASS_ID_TO_NFT_CONTRACT,
-        CW721_ADMIN, CW721_CODE_ID, INCOMING_PROXY, NFT_CONTRACT_TO_CLASS_ID,
+        CollectionData, UniversalAllNftInfoResponse, ADMIN_USED_FOR_CW721, CLASS_ID_TO_CLASS,
+        CLASS_ID_TO_NFT_CONTRACT, CW721_CODE_ID, INCOMING_PROXY, NFT_CONTRACT_TO_CLASS_ID,
         OUTGOING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_PROXY, PO, TOKEN_METADATA,
     },
     token_types::{VoucherCreation, VoucherRedemption},
@@ -62,7 +62,7 @@ where
             ));
         }
 
-        CW721_ADMIN.save(
+        ADMIN_USED_FOR_CW721.save(
             deps.storage,
             &msg.cw721_admin
                 .as_ref()
@@ -336,7 +336,9 @@ where
             CLASS_ID_TO_NFT_CONTRACT.save(deps.storage, class_id.clone(), &cw721_addr)?;
             NFT_CONTRACT_TO_CLASS_ID.save(deps.storage, cw721_addr, &class_id)?;
 
-            let admin = CW721_ADMIN.load(deps.storage)?.map(|a| a.to_string());
+            let admin = ADMIN_USED_FOR_CW721
+                .load(deps.storage)?
+                .map(|a| a.to_string());
             let message = SubMsg::<T>::reply_on_success(
                 WasmMsg::Instantiate2 {
                     admin,
@@ -509,9 +511,9 @@ where
                 }
                 if let Some(cw721_admin) = cw721_admin.clone() {
                     if cw721_admin.is_empty() {
-                        CW721_ADMIN.save(deps.storage, &None)?;
+                        ADMIN_USED_FOR_CW721.save(deps.storage, &None)?;
                     } else {
-                        CW721_ADMIN
+                        ADMIN_USED_FOR_CW721
                             .save(deps.storage, &Some(deps.api.addr_validate(&cw721_admin)?))?;
                     }
                 }

--- a/packages/ics721/src/msg.rs
+++ b/packages/ics721/src/msg.rs
@@ -29,6 +29,8 @@ pub struct InstantiateMsg {
     /// right to do so again. A new pauser may be later nominated by
     /// the CosmWasm level admin via a migration.
     pub pauser: Option<String>,
+    /// The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.
+    pub cw721_admin: Option<String>,
 }
 
 #[cw_serde]
@@ -133,6 +135,10 @@ pub enum QueryMsg {
     #[returns(u64)]
     Cw721CodeId {},
 
+    /// Gets the admin address for instantiating new cw721 contracts. In case of None, contract is immutable.
+    #[returns(Option<Option<::cosmwasm_std::Addr>>)]
+    Cw721Admin {},
+
     /// Gets a list of classID as key (from
     /// NonFungibleTokenPacketData) and cw721 contract as value
     /// (instantiated for that classID).
@@ -181,5 +187,7 @@ pub enum MigrateMsg {
         /// this contract to stop working, and IBCd away NFTs to be
         /// unreturnable as cw721 does not have a mint method in the spec.
         cw721_base_code_id: Option<u64>,
+        /// The admin address for instantiating new cw721 contracts. In case of "", contract is immutable.
+        cw721_admin: Option<String>,
     },
 }

--- a/packages/ics721/src/query.rs
+++ b/packages/ics721/src/query.rs
@@ -4,8 +4,8 @@ use cw_storage_plus::Map;
 use crate::{
     msg::QueryMsg,
     state::{
-        UniversalAllNftInfoResponse, CLASS_ID_TO_CLASS, CLASS_ID_TO_NFT_CONTRACT, CW721_CODE_ID,
-        INCOMING_CLASS_TOKEN_TO_CHANNEL, INCOMING_PROXY, NFT_CONTRACT_TO_CLASS_ID,
+        UniversalAllNftInfoResponse, CLASS_ID_TO_CLASS, CLASS_ID_TO_NFT_CONTRACT, CW721_ADMIN,
+        CW721_CODE_ID, INCOMING_CLASS_TOKEN_TO_CHANNEL, INCOMING_PROXY, NFT_CONTRACT_TO_CLASS_ID,
         OUTGOING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_PROXY, PO, TOKEN_METADATA,
     },
 };
@@ -34,6 +34,7 @@ pub trait Ics721Query {
             QueryMsg::OutgoingProxy {} => to_json_binary(&OUTGOING_PROXY.load(deps.storage)?),
             QueryMsg::IncomingProxy {} => to_json_binary(&INCOMING_PROXY.load(deps.storage)?),
             QueryMsg::Cw721CodeId {} => to_json_binary(&self.query_cw721_code_id(deps)?),
+            QueryMsg::Cw721Admin {} => to_json_binary(&CW721_ADMIN.load(deps.storage)?),
             QueryMsg::NftContracts { start_after, limit } => {
                 to_json_binary(&self.query_nft_contracts(deps, start_after, limit)?)
             }

--- a/packages/ics721/src/query.rs
+++ b/packages/ics721/src/query.rs
@@ -4,9 +4,10 @@ use cw_storage_plus::Map;
 use crate::{
     msg::QueryMsg,
     state::{
-        UniversalAllNftInfoResponse, CLASS_ID_TO_CLASS, CLASS_ID_TO_NFT_CONTRACT, CW721_ADMIN,
-        CW721_CODE_ID, INCOMING_CLASS_TOKEN_TO_CHANNEL, INCOMING_PROXY, NFT_CONTRACT_TO_CLASS_ID,
-        OUTGOING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_PROXY, PO, TOKEN_METADATA,
+        UniversalAllNftInfoResponse, ADMIN_USED_FOR_CW721, CLASS_ID_TO_CLASS,
+        CLASS_ID_TO_NFT_CONTRACT, CW721_CODE_ID, INCOMING_CLASS_TOKEN_TO_CHANNEL, INCOMING_PROXY,
+        NFT_CONTRACT_TO_CLASS_ID, OUTGOING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_PROXY, PO,
+        TOKEN_METADATA,
     },
 };
 use ics721_types::token_types::{Class, ClassId, ClassToken, Token, TokenId};
@@ -34,7 +35,7 @@ pub trait Ics721Query {
             QueryMsg::OutgoingProxy {} => to_json_binary(&OUTGOING_PROXY.load(deps.storage)?),
             QueryMsg::IncomingProxy {} => to_json_binary(&INCOMING_PROXY.load(deps.storage)?),
             QueryMsg::Cw721CodeId {} => to_json_binary(&self.query_cw721_code_id(deps)?),
-            QueryMsg::Cw721Admin {} => to_json_binary(&CW721_ADMIN.load(deps.storage)?),
+            QueryMsg::Cw721Admin {} => to_json_binary(&ADMIN_USED_FOR_CW721.load(deps.storage)?),
             QueryMsg::NftContracts { start_after, limit } => {
                 to_json_binary(&self.query_nft_contracts(deps, start_after, limit)?)
             }

--- a/packages/ics721/src/state.rs
+++ b/packages/ics721/src/state.rs
@@ -39,7 +39,7 @@ pub const INCOMING_CLASS_TOKEN_TO_CHANNEL: Map<(ClassId, TokenId), String> = Map
 /// it's source chain, the metadata is removed from the map.
 pub const TOKEN_METADATA: Map<(ClassId, TokenId), Option<Binary>> = Map::new("j");
 /// The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.
-pub const CW721_ADMIN: Item<Option<Addr>> = Item::new("l");
+pub const ADMIN_USED_FOR_CW721: Item<Option<Addr>> = Item::new("l");
 
 #[derive(Deserialize)]
 pub struct UniversalAllNftInfoResponse {

--- a/packages/ics721/src/state.rs
+++ b/packages/ics721/src/state.rs
@@ -38,6 +38,8 @@ pub const INCOMING_CLASS_TOKEN_TO_CHANNEL: Map<(ClassId, TokenId), String> = Map
 /// is `None`) is stored in this map. When the token is returned to
 /// it's source chain, the metadata is removed from the map.
 pub const TOKEN_METADATA: Map<(ClassId, TokenId), Option<Binary>> = Map::new("j");
+/// The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.
+pub const CW721_ADMIN: Item<Option<Addr>> = Item::new("l");
 
 #[derive(Deserialize)]
 pub struct UniversalAllNftInfoResponse {

--- a/packages/ics721/src/testing/contract.rs
+++ b/packages/ics721/src/testing/contract.rs
@@ -16,7 +16,7 @@ use crate::{
     msg::InstantiateMsg,
     query::Ics721Query,
     state::{
-        CollectionData, CLASS_ID_TO_CLASS, CW721_CODE_ID, INCOMING_PROXY,
+        CollectionData, CLASS_ID_TO_CLASS, CW721_ADMIN, CW721_CODE_ID, INCOMING_PROXY,
         OUTGOING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_PROXY, PO,
     },
     utils::get_collection_data,
@@ -513,6 +513,7 @@ fn test_instantiate() {
         incoming_proxy: Some(incoming_proxy_init_msg.clone()),
         outgoing_proxy: Some(outgoing_proxy_init_msg.clone()),
         pauser: Some(PAUSER_ADDR.to_string()),
+        cw721_admin: Some(ADMIN_ADDR.to_string()),
     };
     let response = Ics721Contract {}
         .instantiate(deps.as_mut(), env.clone(), info, msg.clone())
@@ -531,7 +532,8 @@ fn test_instantiate() {
             INSTANTIATE_OUTGOING_PROXY_REPLY_ID,
         ))
         .add_attribute("method", "instantiate")
-        .add_attribute("cw721_code_id", msg.cw721_base_code_id.to_string());
+        .add_attribute("cw721_code_id", msg.cw721_base_code_id.to_string())
+        .add_attribute("cw721_admin", ADMIN_ADDR);
     assert_eq!(response, expected_response);
     assert_eq!(CW721_CODE_ID.load(&deps.storage).unwrap(), 0);
     // incoming and outgoing proxy initially set to None and set later in sub msg
@@ -542,4 +544,8 @@ fn test_instantiate() {
         Some(Addr::unchecked(PAUSER_ADDR))
     );
     assert!(!PO.paused.load(&deps.storage).unwrap());
+    assert_eq!(
+        CW721_ADMIN.load(&deps.storage).unwrap(),
+        Some(Addr::unchecked(ADMIN_ADDR.to_string()))
+    );
 }

--- a/packages/ics721/src/testing/contract.rs
+++ b/packages/ics721/src/testing/contract.rs
@@ -16,7 +16,7 @@ use crate::{
     msg::InstantiateMsg,
     query::Ics721Query,
     state::{
-        CollectionData, CLASS_ID_TO_CLASS, CW721_ADMIN, CW721_CODE_ID, INCOMING_PROXY,
+        CollectionData, ADMIN_USED_FOR_CW721, CLASS_ID_TO_CLASS, CW721_CODE_ID, INCOMING_PROXY,
         OUTGOING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_PROXY, PO,
     },
     utils::get_collection_data,
@@ -545,7 +545,7 @@ fn test_instantiate() {
     );
     assert!(!PO.paused.load(&deps.storage).unwrap());
     assert_eq!(
-        CW721_ADMIN.load(&deps.storage).unwrap(),
+        ADMIN_USED_FOR_CW721.load(&deps.storage).unwrap(),
         Some(Addr::unchecked(ADMIN_ADDR.to_string()))
     );
 }

--- a/packages/ics721/src/testing/ibc_tests.rs
+++ b/packages/ics721/src/testing/ibc_tests.rs
@@ -108,6 +108,7 @@ fn do_instantiate(deps: DepsMut, env: Env, sender: &str) -> StdResult<Response> 
         incoming_proxy: None,
         outgoing_proxy: None,
         pauser: None,
+        cw721_admin: None,
     };
     Ics721Contract::default().instantiate(deps, env, mock_info(sender, &[]), msg)
 }


### PR DESCRIPTION
new store allows to provide e.g. `Some(addr)` or `None` which will be used for setting admin during instantiation of cw721.