### PR TITLE
scripts for ics721 setup

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,27 @@
+# Setup ICS721
+
+For ICS721 it requires these contracts:
+
+- ICS721: the bridge itself
+- Incoming Proxy: optional contract for filtering incoming packets
+- Outgoing Proxy: optional contract for filtering incoming packets
+
+## Scripts
+
+Scripts for setup must be executed in this order:
+
+1. ICS721 without proxies: [instantiate-ics721.sh](./instantiate-ics721.sh)
+2. Incoming Proxy: [instantiate-incoming-proxy.sh](./instantiate-incoming-proxy.sh)
+3. Outgoing Proxy: [instantiate-outgoing-proxy.sh](instantiate-outgoing-proxy.sh)
+
+In case proxies are used, ICS721 must be migrated for setting incoming and outgoing proxies:
+
+4. Migrate ICS721: TBD
+
+Once running, there are execute messages for proxies, allowing to add and remove channels and collections.
+
+5. WL Collection: TBD
+6. WL Channel: TBD
+
+NOTE:
+Above scripts use [select-chain.sh](./select-chain.sh). For each selected chain there is an `.env` file like `stargaze.env` and `osmosis.env`.

--- a/scripts/instantiate-ics721.sh
+++ b/scripts/instantiate-ics721.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# ----------------------------------------------------
+# - exports CHAIN_NET and CHAIN based on user input  -
+# ----------------------------------------------------
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# select chain
+if [[ -z "$CHAIN" ]]; then
+    source "$SCRIPT_DIR"/select-chain.sh
+    CHAIN=$(select_chain)
+    export CHAIN
+fi
+echo "reading $SCRIPT_DIR/$CHAIN.env"
+source "$SCRIPT_DIR"/"$CHAIN".env
+
+printf -v MSG '{"cw721_base_code_id": %s, "pauser": "%s"}' $CODE_ID_CW721 $WALLET_OWNER
+CMD="$CLI tx wasm instantiate $CODE_ID_ICS721 '$MSG' --label 'ICS721 with rate limiter outgoing proxy'"
+CMD+=" --from $WALLET --admin $WALLET_ADMIN"
+CMD+=" --gas $CLI_GAS --gas-prices $CLI_GAS_PRICES --gas-adjustment $CLI_GAS_ADJUSTMENT"
+CMD+=" --chain-id $CHAIN_ID --node $CHAIN_NODE -y"
+
+echo "executing: $CMD" >&2
+eval $CMD

--- a/scripts/instantiate-incoming-proxy.sh
+++ b/scripts/instantiate-incoming-proxy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# ----------------------------------------------------
+# - exports CHAIN_NET and CHAIN based on user input  -
+# ----------------------------------------------------
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# select chain
+if [[ -z "$CHAIN" ]]; then
+    source "$SCRIPT_DIR"/select-chain.sh
+    CHAIN=$(select_chain)
+    export CHAIN
+fi
+echo "reading $SCRIPT_DIR/$CHAIN.env"
+source "$SCRIPT_DIR"/"$CHAIN".env
+
+printf -v MSG '{"origin": "%s", "channels": %s}' $ADDR_ICS721 $CHANNELS
+LABEL="ICS721 Incoming Whitelist Channel Proxy, Managed by Ark Protocol"
+CMD="$CLI tx wasm instantiate $CODE_ID_INCOMING_PROXY '$MSG'"
+CMD+=" --label '$LABEL'"
+CMD+=" --from $WALLET --admin $WALLET_ADMIN"
+CMD+=" --gas $CLI_GAS --gas-prices $CLI_GAS_PRICES --gas-adjustment $CLI_GAS_ADJUSTMENT"
+CMD+=" --chain-id $CHAIN_ID --node $CHAIN_NODE -y"
+
+echo "executing: $CMD" >&2
+eval $CMD

--- a/scripts/instantiate-outgoing-proxy.sh
+++ b/scripts/instantiate-outgoing-proxy.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# ----------------------------------------------------
+# - exports CHAIN_NET and CHAIN based on user input  -
+# ----------------------------------------------------
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# select chain
+if [[ -z "$CHAIN" ]]; then
+    source "$SCRIPT_DIR"/select-chain.sh
+    CHAIN=$(select_chain)
+    export CHAIN
+fi
+echo "reading $SCRIPT_DIR/$CHAIN.env"
+source "$SCRIPT_DIR"/"$CHAIN".env
+
+MSG=$(
+    cat <<EOF
+{
+    "config": {
+        "origin": "$ADDR_ICS721",
+        "owner": "$WALLET_OWNER"
+    },
+    "proxy": {
+        "rate_limit": {"per_block": 100},
+        "channels": $CHANNELS,
+        "collections": $COLLECTIONS
+    }
+}
+EOF
+)
+LABEL="ICS721 Outgoing Whitelist Channel Proxy"
+CMD="$CLI tx wasm instantiate $CODE_ID_OUTGOING_PROXY '$MSG'"
+CMD+=" --label '$LABEL'"
+CMD+=" --from $WALLET --admin $WALLET_ADMIN"
+CMD+=" --gas $CLI_GAS --gas-prices $CLI_GAS_PRICES --gas-adjustment $CLI_GAS_ADJUSTMENT"
+CMD+=" --chain-id $CHAIN_ID --node $CHAIN_NODE -y"
+
+echo "executing: $CMD" >&2
+eval $CMD

--- a/scripts/osmosis.env
+++ b/scripts/osmosis.env
@@ -1,0 +1,34 @@
+export CLI=osmosisd
+export CLI_OUTPUT=json
+export CLI_DENOM=uosmo
+export CLI_GAS=auto
+export CLI_GAS_PRICE=0.1
+export CLI_GAS_PRICES=$CLI_GAS_PRICE$CLI_DENOM
+export CLI_GAS_ADJUSTMENT=1.1
+export CLI_BROADCAST_MODE=sync
+
+export CHAIN=osmosis
+export CHAIN_ID=osmo-test-5 # osmosis-1
+export CHAIN_NODE=https://osmosis-testnet-rpc.polkachu.com:443 # https://osmosis-rpc.polkachu.com:443
+
+# wallets
+export WALLET=YOUR_WALLET_ADDR # wallet executed the tx
+# - owner of contract
+#   - ics721: used for pauser being able to pause ics721
+#   - incoming and outgoing proxy: used for owner to execute msgs
+export WALLET_OWNER=WALLET_OWNER
+# - admin of contract for migrating contract
+export WALLET_ADMIN=WALLET_ADMIN
+
+export CODE_ID_CW721=CODE_ID_CW721
+export CODE_ID_ICS721=CODE_ID_ICS721
+export ADDR_ICS721=ADDR_ICS721
+
+# proxies
+export CODE_ID_INCOMING_PROXY=7786
+export CODE_ID_OUTGOING_PROXY=7788
+
+# Proxy configs
+# - channels: used as WLs for incoming and outgoing proxy
+export CHANNELS="[\"channel-1\",\"channel-2\"]"
+export COLLECTIONS="[\"ADDR1\",\"ADDR2\"]"

--- a/scripts/select-chain.sh
+++ b/scripts/select-chain.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# ----------------------------------------------------
+# - exports CHAIN based on user input  -
+# ----------------------------------------------------
+
+function select_chain() {
+    # Read chains from the file into an array
+    CHAIN_CHOICES=("stargaze" "osmosis")
+    echo "Available chains: ${CHAIN_CHOICES[*]}" >&2
+
+    echo "Please select the chain:" >&2
+    select SELECTED_CHAIN in "${CHAIN_CHOICES[@]}" "Exit"; do
+        case $SELECTED_CHAIN in
+            "Exit") echo "Exiting..." >&2; return 0 ;;
+            *) if [[ " ${CHAIN_CHOICES[*]} " =~ " ${SELECTED_CHAIN} " ]]; then
+                    echo "Selected chain: $SELECTED_CHAIN" >&2
+                    export CHAIN="$SELECTED_CHAIN"
+                    break
+            else
+                    echo "Invalid choice. Please try again." >&2
+            fi ;;
+        esac
+    done
+
+    export CHAIN="$SELECTED_CHAIN"
+    echo $CHAIN
+}
+
+export -f select_chain

--- a/scripts/stargaze.env
+++ b/scripts/stargaze.env
@@ -1,0 +1,34 @@
+export CLI=starsd
+export CLI_OUTPUT=json
+export CLI_DENOM=ustars
+export CLI_GAS=auto
+export CLI_GAS_PRICE=1.2
+export CLI_GAS_PRICES=$CLI_GAS_PRICE$CLI_DENOM
+export CLI_GAS_ADJUSTMENT=1.1
+export CLI_BROADCAST_MODE=sync
+
+export CHAIN=stargaze
+export CHAIN_ID=elgafar-1 # stargaze-1
+export CHAIN_NODE=https://rpc.elgafar-1.stargaze-apis.com:443 # https://stargaze-rpc.polkachu.com:443 https://rpc.stargaze-apis.com:443 https://stargaze-rpc.publicnode.com:443
+
+# wallets
+export WALLET=YOUR_WALLET_ADDR # wallet executed the tx
+# - owner of contract
+#   - ics721: used for pauser being able to pause ics721
+#   - incoming and outgoing proxy: used for owner to execute msgs
+export WALLET_OWNER=WALLET_OWNER
+# - admin of contract for migrating contract
+export WALLET_ADMIN=WALLET_ADMIN
+
+export CODE_ID_CW721=CODE_ID_CW721
+export CODE_ID_ICS721=CODE_ID_ICS721
+export ADDR_ICS721=ADDR_ICS721
+
+# proxies
+export CODE_ID_INCOMING_PROXY=7786
+export CODE_ID_OUTGOING_PROXY=7788
+
+# Proxy configs
+# - channels: used as WLs for incoming and outgoing proxy
+export CHANNELS="[\"channel-1\",\"channel-2\"]"
+export COLLECTIONS="[\"ADDR1\",\"ADDR2\"]"

--- a/ts-relayer-tests/build.sh
+++ b/ts-relayer-tests/build.sh
@@ -11,7 +11,7 @@ cd "$(git rev-parse --show-toplevel)"
 docker run --rm -v "$(pwd)":/code --platform linux/amd64 \
 	--mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
 	--mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-	cosmwasm/workspace-optimizer:0.15.0
+	cosmwasm/workspace-optimizer:0.15.1
 
 mkdir -p ./ts-relayer-tests/internal
 cp ./artifacts/*.wasm ./ts-relayer-tests/internal


### PR DESCRIPTION
from scripts/README.md:

```md
# Setup ICS721

For ICS721 it requires these contracts:

- ICS721: the bridge itself
- Incoming Proxy: optional contract for filtering incoming packets
- Outgoing Proxy: optional contract for filtering incoming packets

## Scripts

Scripts for setup must be executed in this order:

1. ICS721 without proxies: [instantiate-ics721.sh](./instantiate-ics721.sh)
2. Incoming Proxy: [instantiate-incoming-proxy.sh](./instantiate-incoming-proxy.sh)
3. Outgoing Proxy: [instantiate-outgoing-proxy.sh](instantiate-outgoing-proxy.sh)

In case proxies are used, ICS721 must be migrated for setting incoming and outgoing proxies:

4. Migrate ICS721: TBD

Once running, there are execute messages for proxies, allowing to add and remove channels and collections.

5. WL Collection: TBD
6. WL Channel: TBD

NOTE:
Above scripts use [select-chain.sh](./select-chain.sh). For each selected chain there is an `.env` file like `stargaze.env` and `osmosis.env`.
```