### PR TITLE
Handle custom collections

### DIFF
--- a/packages/ics721/src/execute.rs
+++ b/packages/ics721/src/execute.rs
@@ -695,7 +695,7 @@ where
         for (key, channel) in entries {
             INCOMING_CLASS_TOKEN_TO_CHANNEL.save(deps.storage, key, &channel)?;
         }
-        Ok(Response::default().add_attribute("method", "callback_redeem_outgoing_channel_entries"))
+        Ok(Response::default().add_attribute("method", "callback_save_incoming_channel_entries"))
     }
 
     fn migrate(

--- a/packages/ics721/src/state.rs
+++ b/packages/ics721/src/state.rs
@@ -53,6 +53,13 @@ pub struct UniversalAllNftInfoResponse {
     pub info: UniversalNftInfoResponse,
 }
 
+/// Based on `cw721::ContractInfoResponse v0.18`
+#[derive(Deserialize)]
+pub struct UniversalCollectionInfoResponse {
+    pub name: String,
+    pub symbol: String,
+}
+
 #[derive(Deserialize)]
 pub struct UniversalNftInfoResponse {
     pub token_uri: Option<String>,

--- a/packages/ics721/src/utils.rs
+++ b/packages/ics721/src/utils.rs
@@ -1,8 +1,8 @@
 use cosmwasm_std::{Addr, DepsMut, Empty, Env, StdResult};
-use cw721::{ContractInfoResponse, NumTokensResponse};
+use cw721::NumTokensResponse;
 use cw_ownable::Ownership;
 
-use crate::state::CollectionData;
+use crate::state::{CollectionData, UniversalCollectionInfoResponse};
 
 pub fn get_collection_data(deps: &DepsMut, collection: &Addr) -> StdResult<CollectionData> {
     // cw721 v0.17 and higher holds ownership in the contract
@@ -21,7 +21,7 @@ pub fn get_collection_data(deps: &DepsMut, collection: &Addr) -> StdResult<Colle
         }
     };
     let contract_info = deps.querier.query_wasm_contract_info(collection)?;
-    let ContractInfoResponse { name, symbol } = deps.querier.query_wasm_smart(
+    let UniversalCollectionInfoResponse { name, symbol } = deps.querier.query_wasm_smart(
         collection,
         &cw721_base::msg::QueryMsg::<Empty>::ContractInfo {},
     )?;


### PR DESCRIPTION
#84 - use `UniversalCollectionInfoResponse` for handling custom collections

This is a very small change, but with huge impact: instead of using `cw721::ContractInfoResponse`, now ics721 defines its own `UniversalCollectionInfoResponse`.

Please note that `cw721::ContractInfoResponse` used `cw_serde` - so response needs to EXACTLY match struct. In case of custom collection it may hold addtional props - hence `cw_serde` thows an `deny_unknown_fields` error.

`UniversalCollectionInfoResponse` on the other hand just expects response to hold `name` and `symbol` for deserialization - all other props are ignored.