### PR TITLE
consider contract address length for instantiate2

### DIFF
--- a/contracts/sg-ics721/src/testing/integration_tests.rs
+++ b/contracts/sg-ics721/src/testing/integration_tests.rs
@@ -465,7 +465,7 @@ impl Test {
             .unwrap()
     }
 
-    fn query_contract_addr_length(&mut self) -> Option<usize> {
+    fn query_contract_addr_length(&mut self) -> Option<u32> {
         self.app
             .wrap()
             .query_wasm_smart(self.ics721.clone(), &QueryMsg::ContractAddrLength {})

--- a/contracts/sg-ics721/src/testing/integration_tests.rs
+++ b/contracts/sg-ics721/src/testing/integration_tests.rs
@@ -354,6 +354,7 @@ impl Test {
                     outgoing_proxy,
                     pauser: admin.clone(),
                     cw721_admin: admin,
+                    contract_addr_length: None,
                 },
                 &[],
                 "sg-ics721",
@@ -2350,6 +2351,7 @@ fn test_pause() {
                     outgoing_proxy: None,
                     cw721_base_code_id: None,
                     cw721_admin: None,
+                    contract_addr_length: None,
                 })
                 .unwrap(),
             }
@@ -2404,6 +2406,7 @@ fn test_migration() {
                     outgoing_proxy: None,
                     cw721_base_code_id: Some(12345678),
                     cw721_admin: Some(admin.to_string()),
+                    contract_addr_length: None,
                 })
                 .unwrap(),
             }
@@ -2432,6 +2435,7 @@ fn test_migration() {
                     outgoing_proxy: None,
                     cw721_base_code_id: None,
                     cw721_admin: Some("".to_string()),
+                    contract_addr_length: None,
                 })
                 .unwrap(),
             }

--- a/packages/ics721/schema/ics721.json
+++ b/packages/ics721/schema/ics721.json
@@ -16,7 +16,7 @@
           "integer",
           "null"
         ],
-        "format": "uint",
+        "format": "uint32",
         "minimum": 0.0
       },
       "cw721_admin": {
@@ -1280,12 +1280,12 @@
     },
     "contract_addr_length": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Nullable_uint",
+      "title": "Nullable_uint32",
       "type": [
         "integer",
         "null"
       ],
-      "format": "uint",
+      "format": "uint32",
       "minimum": 0.0
     },
     "cw721_admin": {

--- a/packages/ics721/schema/ics721.json
+++ b/packages/ics721/schema/ics721.json
@@ -10,6 +10,15 @@
       "cw721_base_code_id"
     ],
     "properties": {
+      "contract_addr_length": {
+        "description": "The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).",
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "uint",
+        "minimum": 0.0
+      },
       "cw721_admin": {
         "description": "The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.",
         "type": [
@@ -1048,6 +1057,20 @@
         "additionalProperties": false
       },
       {
+        "description": "Gets the contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).",
+        "type": "object",
+        "required": [
+          "contract_addr_length"
+        ],
+        "properties": {
+          "contract_addr_length": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Gets a list of classID as key (from NonFungibleTokenPacketData) and cw721 contract as value (instantiated for that classID).",
         "type": "object",
         "required": [
@@ -1254,6 +1277,16 @@
           "type": "string"
         }
       }
+    },
+    "contract_addr_length": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Nullable_uint",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint",
+      "minimum": 0.0
     },
     "cw721_admin": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/ics721/schema/raw/instantiate.json
+++ b/packages/ics721/schema/raw/instantiate.json
@@ -6,6 +6,15 @@
     "cw721_base_code_id"
   ],
   "properties": {
+    "contract_addr_length": {
+      "description": "The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint",
+      "minimum": 0.0
+    },
     "cw721_admin": {
       "description": "The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.",
       "type": [

--- a/packages/ics721/schema/raw/instantiate.json
+++ b/packages/ics721/schema/raw/instantiate.json
@@ -12,7 +12,7 @@
         "integer",
         "null"
       ],
-      "format": "uint",
+      "format": "uint32",
       "minimum": 0.0
     },
     "cw721_admin": {

--- a/packages/ics721/schema/raw/query.json
+++ b/packages/ics721/schema/raw/query.json
@@ -204,6 +204,20 @@
       "additionalProperties": false
     },
     {
+      "description": "Gets the contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).",
+      "type": "object",
+      "required": [
+        "contract_addr_length"
+      ],
+      "properties": {
+        "contract_addr_length": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Gets a list of classID as key (from NonFungibleTokenPacketData) and cw721 contract as value (instantiated for that classID).",
       "type": "object",
       "required": [

--- a/packages/ics721/schema/raw/response_to_contract_addr_length.json
+++ b/packages/ics721/schema/raw/response_to_contract_addr_length.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Nullable_uint",
+  "type": [
+    "integer",
+    "null"
+  ],
+  "format": "uint",
+  "minimum": 0.0
+}

--- a/packages/ics721/schema/raw/response_to_contract_addr_length.json
+++ b/packages/ics721/schema/raw/response_to_contract_addr_length.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Nullable_uint",
+  "title": "Nullable_uint32",
   "type": [
     "integer",
     "null"
   ],
-  "format": "uint",
+  "format": "uint32",
   "minimum": 0.0
 }

--- a/packages/ics721/src/execute.rs
+++ b/packages/ics721/src/execute.rs
@@ -715,7 +715,6 @@ where
         _env: Env,
         msg: MigrateMsg,
     ) -> Result<Response<T>, ContractError> {
-        println!(">>>>>>>> msg: {:?}", msg);
         match msg {
             MigrateMsg::WithUpdate {
                 pauser,

--- a/packages/ics721/src/execute.rs
+++ b/packages/ics721/src/execute.rs
@@ -78,11 +78,9 @@ where
 
         let contract_addr_length = msg.contract_addr_length;
         if let Some(contract_addr_length) = contract_addr_length {
-            if let Some(contract_addr_length) = contract_addr_length {
-                CONTRACT_ADDR_LENGTH.save(deps.storage, &contract_addr_length)?;
-            } else {
-                CONTRACT_ADDR_LENGTH.remove(deps.storage);
-            }
+            CONTRACT_ADDR_LENGTH.save(deps.storage, &contract_addr_length)?;
+        } else {
+            CONTRACT_ADDR_LENGTH.remove(deps.storage);
         }
 
         Ok(Response::default()
@@ -96,10 +94,7 @@ where
             )
             .add_attribute(
                 "contract_addr_length",
-                contract_addr_length.map_or_else(
-                    || "none".to_string(),
-                    |or| or.map_or_else(|| "deleted".to_string(), |or| or.to_string()),
-                ),
+                contract_addr_length.map_or_else(|| "none".to_string(), |or| or.to_string()),
             ))
     }
 
@@ -720,6 +715,7 @@ where
         _env: Env,
         msg: MigrateMsg,
     ) -> Result<Response<T>, ContractError> {
+        println!(">>>>>>>> msg: {:?}", msg);
         match msg {
             MigrateMsg::WithUpdate {
                 pauser,
@@ -759,11 +755,9 @@ where
                 }
 
                 if let Some(contract_addr_length) = contract_addr_length {
-                    if let Some(contract_addr_length) = contract_addr_length {
-                        CONTRACT_ADDR_LENGTH.save(deps.storage, &contract_addr_length)?;
-                    } else {
-                        CONTRACT_ADDR_LENGTH.remove(deps.storage);
-                    }
+                    CONTRACT_ADDR_LENGTH.save(deps.storage, &contract_addr_length)?;
+                } else {
+                    CONTRACT_ADDR_LENGTH.remove(deps.storage);
                 }
 
                 let response = Response::default()
@@ -796,10 +790,8 @@ where
                     )
                     .add_attribute(
                         "contract_addr_length",
-                        contract_addr_length.map_or_else(
-                            || "none".to_string(),
-                            |or| or.map_or_else(|| "deleted".to_string(), |or| or.to_string()),
-                        ),
+                        contract_addr_length
+                            .map_or_else(|| "none".to_string(), |or| or.to_string()),
                     );
 
                 self.migrate_legacy(deps, response)

--- a/packages/ics721/src/helpers.rs
+++ b/packages/ics721/src/helpers.rs
@@ -4,7 +4,11 @@ use cosmwasm_std::{
 };
 use serde::Deserialize;
 
-use crate::{ibc::ACK_CALLBACK_REPLY_ID, state::INCOMING_PROXY, ContractError};
+use crate::{
+    ibc::ACK_CALLBACK_REPLY_ID,
+    state::{CONTRACT_ADDR_LENGTH, INCOMING_PROXY},
+    ContractError,
+};
 use ics721_types::{
     ibc_types::NonFungibleTokenPacketData,
     types::{
@@ -147,8 +151,13 @@ pub fn get_instantiate2_address(
     let CodeInfoResponse { checksum, .. } = deps.querier.query_wasm_code_info(code_id)?;
 
     let canonical_cw721_addr = instantiate2_address(&checksum, &canonical_creator, salt)?;
-
-    Ok(deps.api.addr_humanize(&canonical_cw721_addr)?)
+    if let Some(len) = CONTRACT_ADDR_LENGTH.may_load(deps.storage)? {
+        Ok(deps
+            .api
+            .addr_humanize(&canonical_cw721_addr[..len].into())?)
+    } else {
+        Ok(deps.api.addr_humanize(&canonical_cw721_addr)?)
+    }
 }
 
 mod test {

--- a/packages/ics721/src/helpers.rs
+++ b/packages/ics721/src/helpers.rs
@@ -151,10 +151,11 @@ pub fn get_instantiate2_address(
     let CodeInfoResponse { checksum, .. } = deps.querier.query_wasm_code_info(code_id)?;
 
     let canonical_cw721_addr = instantiate2_address(&checksum, &canonical_creator, salt)?;
-    if let Some(len) = CONTRACT_ADDR_LENGTH.may_load(deps.storage)? {
+    if let Some(contract_addr_length) = CONTRACT_ADDR_LENGTH.may_load(deps.storage)? {
+        let contract_addr_length = contract_addr_length as usize;
         Ok(deps
             .api
-            .addr_humanize(&canonical_cw721_addr[..len].into())?)
+            .addr_humanize(&canonical_cw721_addr[..contract_addr_length].into())?)
     } else {
         Ok(deps.api.addr_humanize(&canonical_cw721_addr)?)
     }

--- a/packages/ics721/src/msg.rs
+++ b/packages/ics721/src/msg.rs
@@ -31,6 +31,8 @@ pub struct InstantiateMsg {
     pub pauser: Option<String>,
     /// The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.
     pub cw721_admin: Option<String>,
+    /// The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
+    pub contract_addr_length: Option<Option<usize>>,
 }
 
 #[cw_serde]
@@ -212,5 +214,7 @@ pub enum MigrateMsg {
         cw721_base_code_id: Option<u64>,
         /// The admin address for instantiating new cw721 contracts. In case of "", contract is immutable.
         cw721_admin: Option<String>,
+        /// The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
+        contract_addr_length: Option<Option<usize>>,
     },
 }

--- a/packages/ics721/src/msg.rs
+++ b/packages/ics721/src/msg.rs
@@ -32,7 +32,7 @@ pub struct InstantiateMsg {
     /// The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.
     pub cw721_admin: Option<String>,
     /// The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
-    pub contract_addr_length: Option<usize>,
+    pub contract_addr_length: Option<u32>,
 }
 
 #[cw_serde]
@@ -165,7 +165,7 @@ pub enum QueryMsg {
     Cw721Admin {},
 
     /// Gets the contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
-    #[returns(Option<usize>)]
+    #[returns(Option<u32>)]
     ContractAddrLength {},
 
     /// Gets a list of classID as key (from
@@ -219,6 +219,6 @@ pub enum MigrateMsg {
         /// The admin address for instantiating new cw721 contracts. In case of "", contract is immutable.
         cw721_admin: Option<String>,
         /// The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
-        contract_addr_length: Option<usize>,
+        contract_addr_length: Option<u32>,
     },
 }

--- a/packages/ics721/src/msg.rs
+++ b/packages/ics721/src/msg.rs
@@ -32,7 +32,7 @@ pub struct InstantiateMsg {
     /// The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.
     pub cw721_admin: Option<String>,
     /// The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
-    pub contract_addr_length: Option<Option<usize>>,
+    pub contract_addr_length: Option<usize>,
 }
 
 #[cw_serde]
@@ -164,6 +164,10 @@ pub enum QueryMsg {
     #[returns(Option<Option<::cosmwasm_std::Addr>>)]
     Cw721Admin {},
 
+    /// Gets the contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
+    #[returns(Option<usize>)]
+    ContractAddrLength {},
+
     /// Gets a list of classID as key (from
     /// NonFungibleTokenPacketData) and cw721 contract as value
     /// (instantiated for that classID).
@@ -215,6 +219,6 @@ pub enum MigrateMsg {
         /// The admin address for instantiating new cw721 contracts. In case of "", contract is immutable.
         cw721_admin: Option<String>,
         /// The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
-        contract_addr_length: Option<Option<usize>>,
+        contract_addr_length: Option<usize>,
     },
 }

--- a/packages/ics721/src/query.rs
+++ b/packages/ics721/src/query.rs
@@ -5,8 +5,8 @@ use crate::{
     msg::QueryMsg,
     state::{
         UniversalAllNftInfoResponse, ADMIN_USED_FOR_CW721, CLASS_ID_AND_NFT_CONTRACT_INFO,
-        CLASS_ID_TO_CLASS, CW721_CODE_ID, INCOMING_CLASS_TOKEN_TO_CHANNEL, INCOMING_PROXY,
-        OUTGOING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_PROXY, PO, TOKEN_METADATA,
+        CLASS_ID_TO_CLASS, CONTRACT_ADDR_LENGTH, CW721_CODE_ID, INCOMING_CLASS_TOKEN_TO_CHANNEL,
+        INCOMING_PROXY, OUTGOING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_PROXY, PO, TOKEN_METADATA,
     },
 };
 use ics721_types::token_types::{Class, ClassId, ClassToken, Token, TokenId};
@@ -35,6 +35,9 @@ pub trait Ics721Query {
             QueryMsg::IncomingProxy {} => to_json_binary(&INCOMING_PROXY.load(deps.storage)?),
             QueryMsg::Cw721CodeId {} => to_json_binary(&query_cw721_code_id(deps)?),
             QueryMsg::Cw721Admin {} => to_json_binary(&ADMIN_USED_FOR_CW721.load(deps.storage)?),
+            QueryMsg::ContractAddrLength {} => {
+                to_json_binary(&CONTRACT_ADDR_LENGTH.may_load(deps.storage)?)
+            }
             QueryMsg::NftContracts { start_after, limit } => {
                 to_json_binary(&query_nft_contracts(deps, start_after, limit)?)
             }

--- a/packages/ics721/src/state.rs
+++ b/packages/ics721/src/state.rs
@@ -52,7 +52,7 @@ pub const ADMIN_USED_FOR_CW721: Item<Option<Addr>> = Item::new("l");
 /// The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
 /// So length must be shorter than 32. For example, Injective has 20 length address.
 /// Bug: https://github.com/CosmWasm/cosmwasm/issues/2155
-pub const CONTRACT_ADDR_LENGTH: Item<usize> = Item::new("n");
+pub const CONTRACT_ADDR_LENGTH: Item<u32> = Item::new("n");
 
 #[derive(Deserialize)]
 pub struct UniversalAllNftInfoResponse {

--- a/packages/ics721/src/state.rs
+++ b/packages/ics721/src/state.rs
@@ -38,14 +38,21 @@ pub const CLASS_ID_TO_CLASS: Map<ClassId, Class> = Map::new("g");
 pub const OUTGOING_CLASS_TOKEN_TO_CHANNEL: Map<(ClassId, TokenId), String> = Map::new("h");
 /// Same as above, but for NFTs arriving at this contract.
 pub const INCOMING_CLASS_TOKEN_TO_CHANNEL: Map<(ClassId, TokenId), String> = Map::new("i");
+
 /// Maps (class ID, token ID) -> token metadata. Used to store
 /// on-chain metadata for tokens that have arrived from other
 /// chains. When a token arrives, it's metadata (regardless of if it
 /// is `None`) is stored in this map. When the token is returned to
 /// it's source chain, the metadata is removed from the map.
 pub const TOKEN_METADATA: Map<(ClassId, TokenId), Option<Binary>> = Map::new("j");
+
 /// The admin address for instantiating new cw721 contracts. In case of None, contract is immutable.
 pub const ADMIN_USED_FOR_CW721: Item<Option<Addr>> = Item::new("l");
+
+/// The optional contract address length being used for instantiate2. In case of None, default length is 32 (standard in cosmwasm).
+/// So length must be shorter than 32. For example, Injective has 20 length address.
+/// Bug: https://github.com/CosmWasm/cosmwasm/issues/2155
+pub const CONTRACT_ADDR_LENGTH: Item<usize> = Item::new("n");
 
 #[derive(Deserialize)]
 pub struct UniversalAllNftInfoResponse {

--- a/packages/ics721/src/testing/contract.rs
+++ b/packages/ics721/src/testing/contract.rs
@@ -533,7 +533,7 @@ fn test_instantiate() {
         Some(incoming_proxy_init_msg.clone()),
         Some(outgoing_proxy_init_msg.clone()),
     );
-    msg.contract_addr_length = Some(Some(20));
+    msg.contract_addr_length = Some(20);
     let response = Ics721Contract {}
         .instantiate(deps.as_mut(), env.clone(), info, msg.clone())
         .unwrap();
@@ -586,7 +586,7 @@ fn test_migrate() {
         incoming_proxy: Some("incoming".to_string()),
         cw721_base_code_id: Some(1),
         cw721_admin: Some("some_other_admin".to_string()),
-        contract_addr_length: Some(Some(20)),
+        contract_addr_length: Some(20),
     };
 
     // before migrate, populate legacy

--- a/packages/ics721/src/testing/ibc_tests.rs
+++ b/packages/ics721/src/testing/ibc_tests.rs
@@ -111,6 +111,7 @@ fn do_instantiate(deps: DepsMut, env: Env, sender: &str) -> StdResult<Response> 
         outgoing_proxy: None,
         pauser: None,
         cw721_admin: None,
+        contract_addr_length: None,
     };
     Ics721Contract::default().instantiate(deps, env, mock_info(sender, &[]), msg)
 }

--- a/packages/ics721/src/testing/integration_tests.rs
+++ b/packages/ics721/src/testing/integration_tests.rs
@@ -472,7 +472,7 @@ impl Test {
             .unwrap()
     }
 
-    fn query_contract_addr_length(&mut self) -> Option<usize> {
+    fn query_contract_addr_length(&mut self) -> Option<u32> {
         self.app
             .wrap()
             .query_wasm_smart(self.ics721.clone(), &QueryMsg::ContractAddrLength {})

--- a/packages/ics721/src/testing/integration_tests.rs
+++ b/packages/ics721/src/testing/integration_tests.rs
@@ -472,6 +472,13 @@ impl Test {
             .unwrap()
     }
 
+    fn query_contract_addr_length(&mut self) -> Option<usize> {
+        self.app
+            .wrap()
+            .query_wasm_smart(self.ics721.clone(), &QueryMsg::ContractAddrLength {})
+            .unwrap()
+    }
+
     fn query_nft_contracts(&mut self) -> Vec<(String, Addr)> {
         self.app
             .wrap()
@@ -2308,7 +2315,7 @@ fn test_migration() {
                     outgoing_proxy: None,
                     cw721_base_code_id: Some(12345678),
                     cw721_admin: Some(admin.to_string()),
-                    contract_addr_length: None,
+                    contract_addr_length: Some(20),
                 })
                 .unwrap(),
             }
@@ -2322,24 +2329,25 @@ fn test_migration() {
     assert!(proxy.is_none());
     let cw721_code_id = test.query_cw721_id();
     assert_eq!(cw721_code_id, 12345678);
-    assert_eq!(test.query_cw721_admin(), Some(admin),);
+    assert_eq!(test.query_cw721_admin(), Some(admin));
+    assert_eq!(test.query_contract_addr_length(), Some(20),);
 
     // migrate without changing code id
+    let msg = MigrateMsg::WithUpdate {
+        pauser: None,
+        incoming_proxy: None,
+        outgoing_proxy: None,
+        cw721_base_code_id: None,
+        cw721_admin: Some("".to_string()),
+        contract_addr_length: None,
+    };
     test.app
         .execute(
             test.app.api().addr_make(ICS721_ADMIN_AND_PAUSER),
             WasmMsg::Migrate {
                 contract_addr: test.ics721.to_string(),
                 new_code_id: test.ics721_id,
-                msg: to_json_binary(&MigrateMsg::WithUpdate {
-                    pauser: None,
-                    incoming_proxy: None,
-                    outgoing_proxy: None,
-                    cw721_base_code_id: None,
-                    cw721_admin: Some("".to_string()),
-                    contract_addr_length: None,
-                })
-                .unwrap(),
+                msg: to_json_binary(&msg).unwrap(),
             }
             .into(),
         )
@@ -2351,5 +2359,6 @@ fn test_migration() {
     assert!(proxy.is_none());
     let cw721_code_id = test.query_cw721_id();
     assert_eq!(cw721_code_id, 12345678);
-    assert_eq!(test.query_cw721_admin(), None,);
+    assert_eq!(test.query_cw721_admin(), None);
+    assert_eq!(test.query_contract_addr_length(), None);
 }

--- a/packages/ics721/src/testing/integration_tests.rs
+++ b/packages/ics721/src/testing/integration_tests.rs
@@ -354,6 +354,7 @@ impl Test {
                     outgoing_proxy,
                     pauser: admin.clone(),
                     cw721_admin: admin.clone(),
+                    contract_addr_length: None,
                 },
                 &[],
                 "ics721-base",
@@ -2251,6 +2252,7 @@ fn test_pause() {
                     outgoing_proxy: None,
                     cw721_base_code_id: None,
                     cw721_admin: None,
+                    contract_addr_length: None,
                 })
                 .unwrap(),
             }
@@ -2306,6 +2308,7 @@ fn test_migration() {
                     outgoing_proxy: None,
                     cw721_base_code_id: Some(12345678),
                     cw721_admin: Some(admin.to_string()),
+                    contract_addr_length: None,
                 })
                 .unwrap(),
             }
@@ -2334,6 +2337,7 @@ fn test_migration() {
                     outgoing_proxy: None,
                     cw721_base_code_id: None,
                     cw721_admin: Some("".to_string()),
+                    contract_addr_length: None,
                 })
                 .unwrap(),
             }


### PR DESCRIPTION
This PR adds new `CONTRACT_ADDR_LENGTH: Item<usize> = Item::new("n")` storage. In most case it can be left empty. For Injective it contains `20` as value.

By default cosmwasm considers addresses with 32 bytes as a constant. Injective on the other hand is of length 20 bytes.
See details here: https://github.com/CosmWasm/cosmwasm/issues/2155

So `instantiate2` fails, when transferring from a chain to Injective. Solution is simple - as suggested by Simon: slicing and taking first 20 bytes.

This has been tested on testnet, Stargaze -> Injective, and works like a charm.
