### PR TITLE
use sg721-metadata-onchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,10 +1266,23 @@ dependencies = [
  "cw721-base 0.18.0 (git+https://github.com/public-awesome/cw-nfts?branch=release/v0.18.0)",
  "ics721",
  "ics721-types 0.1.0",
+ "sg-metadata",
  "sg-std",
  "sg721",
  "sg721-base",
+ "sg721-metadata-onchain",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "sg-metadata"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79c457d59b63bc9bf33c08eab50dd857af54d89e2f7098ea2a7eef6cd082e95"
+dependencies = [
+ "cosmwasm-schema",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -1321,6 +1334,25 @@ dependencies = [
  "sg721",
  "thiserror",
  "url",
+]
+
+[[package]]
+name = "sg721-metadata-onchain"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5bb48d339e3d75cec1ad4dcd2e80ecd2175b349aafb63974517d383162d686"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-ownable 0.5.1",
+ "cw2 1.1.2",
+ "cw721-base 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars",
+ "serde",
+ "sg-metadata",
+ "sg-std",
+ "sg721",
+ "sg721-base",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,12 @@ sha2 = "^0.10"
 serde = "^1.0"
 thiserror = "^1.0"
 # Stargaze libs
+sg-metadata = "^3.14"
 sg-std = "^3.2"
 sg-multi-test = "^3.1"
 sg721 = "^3.3"
-sg721-base = "^3.3"
+sg721-base = "^3.14"
+sg721-metadata-onchain = "^3.14"
 # packages and contracts
 cw-cii = { path = "./packages/cw-cii" }
 cw-pause-once = { path = "./packages/cw-pause-once" }

--- a/contracts/sg-ics721/Cargo.toml
+++ b/contracts/sg-ics721/Cargo.toml
@@ -19,9 +19,11 @@ cw2 = { workspace = true }
 cw721 = { workspace = true }
 ics721 = { workspace = true }
 ics721-types = { workspace = true }
+sg-metadata = { workspace = true}
 sg-std = { workspace = true}
 sg721 = { workspace = true }
 sg721-base = { workspace = true, features = ["library"] }
+sg721-metadata-onchain = { workspace = true, features = ["library"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/contracts/sg-ics721/src/execute.rs
+++ b/contracts/sg-ics721/src/execute.rs
@@ -154,9 +154,9 @@ impl Ics721Execute for SgIcs721Contract {
 
         let msg = sg721_metadata_onchain::ExecuteMsg::Mint {
             token_id,
-            token_uri,
+            token_uri, // holds off-chain metadata
             owner,
-            extension,
+            extension, // holds on-chain metadata
         };
         to_json_binary(&msg)
     }

--- a/packages/ics721/src/execute.rs
+++ b/packages/ics721/src/execute.rs
@@ -766,9 +766,9 @@ where
 
         let msg = cw721_metadata_onchain::msg::ExecuteMsg::Mint {
             token_id,
-            token_uri,
+            token_uri, // holds off-chain metadata
             owner,
-            extension,
+            extension, // holds on-chain metadata
         };
         to_json_binary(&msg)
     }

--- a/packages/ics721/src/execute.rs
+++ b/packages/ics721/src/execute.rs
@@ -748,8 +748,8 @@ where
         data: Option<Binary>,
     ) -> StdResult<Binary> {
         // parse token data and check whether it is of type NftExtension
-        let extension: Option<NftExtensionMsg> = match data {
-            Some(data) => from_json::<NftExtension>(data)
+        let extension = data.and_then(|binary| {
+            from_json::<NftExtension>(binary)
                 .ok()
                 .map(|ext| NftExtensionMsg {
                     animation_url: ext.animation_url,
@@ -761,9 +761,8 @@ where
                     image_data: ext.image_data,
                     youtube_url: ext.youtube_url,
                     name: ext.name,
-                }),
-            None => None,
-        };
+                })
+        });
 
         let msg = cw721_metadata_onchain::msg::ExecuteMsg::Mint {
             token_id,


### PR DESCRIPTION
This PR uses sg721-metadata-onchain contract. It allows incoming NFTs with onchain metadata. If there is no onchain data, then `None` is used in `Metadata`.